### PR TITLE
enable HEIC in Dockerfile + changes due to linting

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,71 +1,101 @@
-FROM alpine:edge
+FROM alpine:edge AS BUILDIMG
 LABEL maintainer="Sergey Alexandrovich <darthsim@gmail.com>"
+
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 ENV GOPATH /go
 ENV PATH /usr/local/go/bin:$PATH
 
-ADD . /go/src/github.com/DarthSim/imgproxy
+COPY . /go/src/github.com/DarthSim/imgproxy
 WORKDIR /go/src/github.com/DarthSim/imgproxy
 
 # Install dependencies
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
   && apk --no-cache upgrade \
-  && apk add --no-cache curl ca-certificates go gcc g++ make musl-dev fftw-dev glib-dev expat-dev \
-    libjpeg-turbo-dev libpng-dev libwebp-dev giflib-dev librsvg-dev libexif-dev lcms2-dev libimagequant-dev
+  && apk --no-cache add \
+    curl \
+    ca-certificates \
+    go \
+    gcc \
+    g++ \
+    glib-dev \
+    make \
+    musl-dev \
+    expat-dev \
+    fftw-dev \
+    giflib-dev \
+    lcms2-dev \
+    libexif-dev \
+    libheif-dev \
+    libimagequant-dev \
+    libjpeg-turbo-dev \
+    libpng-dev \
+    librsvg-dev \
+    libwebp-dev \
+  && rm -rf /var/cache/apk*
 
 # Build ImageMagick
-RUN cd /root \
-  && mkdir ImageMagick \
-  && curl -Ls https://imagemagick.org/download/ImageMagick.tar.gz | tar -xz -C ImageMagick --strip-components 1 \
-  && cd ImageMagick \
+WORKDIR /root/ImageMagick
+RUN curl -LfsS https://imagemagick.org/download/ImageMagick.tar.gz | tar -xz --strip-components 1 \
   && ./configure \
-    --enable-silent-rules \
-    --disable-static \
-    --disable-openmp \
     --disable-deprecated \
     --disable-docs \
+    --disable-openmp \
+    --disable-static \
+    --enable-silent-rules \
     --with-threads \
-    --without-magick-plus-plus \
-    --without-utilities \
-    --without-perl \
     --without-bzlib \
     --without-dps \
     --without-freetype \
+    --without-heic \
     --without-jbig \
     --without-jpeg \
     --without-lcms \
     --without-lzma \
+    --without-magick-plus-plus \
+    --without-perl \
     --without-png \
     --without-tiff \
-    --without-wmf \
-    --without-xml \
+    --without-utilities \
     --without-webp \
+    --without-wmf \
+    --without-x \
+    --without-xml \
   && make install-strip
 
-# Build libvips
-RUN cd /root \
-  && export VIPS_VERSION=$(curl -s "https://api.github.com/repos/libvips/libvips/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') \
-  && echo "Vips version: $VIPS_VERSION" \
-  && curl -Ls https://github.com/libvips/libvips/releases/download/v$VIPS_VERSION/vips-$VIPS_VERSION.tar.gz | tar -xz \
-  && cd vips-$VIPS_VERSION \
-  && ./configure \
-    --disable-magickload \
-    --without-python \
-    --without-tiff \
-    --without-OpenEXR \
-    --enable-debug=no \
-    --disable-static \
-    --enable-silent-rules \
-  && make install-strip
+# Build libvips (latest or specified version)
+ARG VIPS_VERSION=latest
+WORKDIR /root/vips-${VIPS_VERSION}
+RUN if [ "${VIPS_VERSION}" = "latest" ]; then \
+      VIPS_VERSION=$(curl -fsS 'https://api.github.com/repos/libvips/libvips/releases/latest' | sed -n 's/.*tag_name":\s"v\(.*\)".*/\1/p' | head -1); \
+    fi \
+    && echo "Vips version: $VIPS_VERSION" \
+    && curl -LfsS https://github.com/libvips/libvips/releases/download/v$VIPS_VERSION/vips-$VIPS_VERSION.tar.gz | tar -xz --strip 1 \
+    && ./configure \
+      --disable-debug \
+      --disable-dependency-tracking \
+      --disable-magickload \
+      --disable-static \
+      --enable-debug=no \
+      --enable-gtk-doc-html=no \
+      --enable-gtk-doc=no \
+      --enable-pyvips8=no \
+      --enable-silent-rules \
+      --without-OpenEXR \
+      --without-gsf \
+      --without-orc \
+      --without-tiff \
+    && make check \
+    && make install-strip
 
 # Build imgproxy
-RUN cd /go/src/github.com/DarthSim/imgproxy \
-  && CGO_LDFLAGS_ALLOW="-s|-w" go build -v -o /usr/local/bin/imgproxy
+WORKDIR /go/src/github.com/DarthSim/imgproxy
+RUN CGO_LDFLAGS_ALLOW="-s|-w" go build -v -o /usr/local/bin/imgproxy
 
 # Copy compiled libs here to copy them to the final image
-RUN cd /root \
-  && mkdir libs \
-  && ldd /usr/local/bin/imgproxy | grep /usr/local/lib/ | awk '{print $3}' | xargs -I '{}' cp '{}' libs/
+WORKDIR /root/libs
+WORKDIR /root
+RUN ldd /usr/local/bin/imgproxy | grep /usr/local/lib/ | awk '{print $3}' | xargs -I '{}' cp '{}' libs/
 
 # ==================================================================================================
 # Final image
@@ -75,12 +105,26 @@ LABEL maintainer="Sergey Alexandrovich <darthsim@gmail.com>"
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
   && apk --no-cache upgrade \
-  && apk add --no-cache bash ca-certificates fftw glib expat libjpeg-turbo libpng \
-    libwebp giflib librsvg libgsf libexif lcms2 libimagequant\
+  && apk --no-cache add \
+    bash \
+    ca-certificates \
+    expat \
+    fftw \
+    giflib \
+    glib \
+    lcms2 \
+    libexif \
+    libgsf \
+    libheif \
+    libimagequant \
+    libjpeg-turbo \
+    libpng \
+    librsvg \
+    libwebp \
   && rm -rf /var/cache/apk*
 
-COPY --from=0 /usr/local/bin/imgproxy /usr/local/bin/
-COPY --from=0 /root/libs/* /usr/local/lib/
+COPY --from=BUILDIMG /usr/local/bin/imgproxy /usr/local/bin/
+COPY --from=BUILDIMG /root/libs/* /usr/local/lib/
 
 ENV VIPS_WARNING=0
 ENV MALLOC_ARENA_MAX=4


### PR DESCRIPTION
- added "libheif-dev" for build image and "libheif1" for final image to
  enable HEIF support by default
- added imagemagick configure cli args:
  - "--without-heic"
  - "--without-x"
- added docker build-arg "VIPS_VERSION" to specify libvips version to
  download and compile – defaults to latest tag name
- added libvips configure cli args:
  - "--disable-debug"
  - "--disable-dependency-tracking"
  - "--enable-gtk-doc=no"
  - "--enable-gtk-doc-html=no"
  - "--enable-pyvips8=no"
  - "--without-gsf"
  - "--without-orc"
- removed libvips configure cli arg "--without-python" as it's not recognized
- add "make check" to run libvips tests after configuration
- various changes after linting the Dockerfile with hadolint
  ``docker run --rm -i hadolint/hadolint:latest-debian < docker/Dockerfile``
  - usually it's the usage of WORKDIR instead of mkdir/cd for compiling
  - use BUILDIMG as named image reference for copying into final image
  - COPY current folder (instead of ADD)
  - enable pipefail for shell to fail correctly when using piped commands
  - make curl commands fail when they run into 404 etc.
- lint warnings left include:
  - "DL3017 Do not use apk upgrade" (edge "testing" repo is needed for libimagequant)
  - "DL3018 Pin versions in apk add." (didn't dive into lib versions…)
  - "SC2086 Double quote to prevent globbing and word splitting." (sed'ing version)
- formatting/sorting in RUN commands for better diffs the next time :x